### PR TITLE
Reorganize CE table

### DIFF
--- a/GGXXACPR_Win.CT
+++ b/GGXXACPR_Win.CT
@@ -2,64 +2,88 @@
 <CheatTable CheatEngineTableVersion="29">
   <CheatEntries>
     <CheatEntry>
+      <ID>43</ID>
+      <Description>"Disable IsDebuggerPresent"</Description>
+      <LastState/>
+      <VariableType>Auto Assembler Script</VariableType>
+      <AssemblerScript>define(address,"KERNELBASE.IsDebuggerPresent")
+define(bytes, 64 A1 30 00 00 00 0F B6 40 02)
+[ENABLE]
+assert(address, bytes)
+
+address:
+        mov eax, 0
+        nop
+        nop
+        nop
+        nop
+        nop
+
+[DISABLE]
+address:
+         db bytes
+</AssemblerScript>
+    </CheatEntry>
+    <CheatEntry>
       <ID>18</ID>
       <Description>"Settings"</Description>
+      <Options moHideChildren="1"/>
       <LastState Value="" RealAddress="00000000"/>
       <GroupHeader>1</GroupHeader>
       <CheatEntries>
         <CheatEntry>
           <ID>3</ID>
           <Description>"Difficulty"</Description>
-          <LastState Value="2" RealAddress="012D6164"/>
+          <LastState Value="0" RealAddress="00806164"/>
           <VariableType>4 Bytes</VariableType>
           <Address>GGXXACPR_Win.exe+4E6164+0</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>5</ID>
           <Description>"Time"</Description>
-          <LastState Value="2" RealAddress="012D617C"/>
+          <LastState Value="0" RealAddress="0080617C"/>
           <VariableType>4 Bytes</VariableType>
           <Address>GGXXACPR_Win.exe+4E6164+18</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>7</ID>
           <Description>"Rounds"</Description>
-          <LastState Value="1" RealAddress="012D6194"/>
+          <LastState Value="0" RealAddress="00806194"/>
           <VariableType>4 Bytes</VariableType>
           <Address>GGXXACPR_Win.exe+4E6164+30</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>9</ID>
           <Description>"Victory BGM"</Description>
-          <LastState Value="0" RealAddress="012D61AC"/>
+          <LastState Value="0" RealAddress="008061AC"/>
           <VariableType>4 Bytes</VariableType>
           <Address>GGXXACPR_Win.exe+4E6164+48</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>11</ID>
           <Description>"Sol VA"</Description>
-          <LastState Value="0" RealAddress="012D61C4"/>
+          <LastState Value="0" RealAddress="008061C4"/>
           <VariableType>4 Bytes</VariableType>
           <Address>GGXXACPR_Win.exe+4E6164+60</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>13</ID>
           <Description>"HOS VA"</Description>
-          <LastState Value="0" RealAddress="012D61DC"/>
+          <LastState Value="0" RealAddress="008061DC"/>
           <VariableType>4 Bytes</VariableType>
           <Address>GGXXACPR_Win.exe+4E6164+78</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>15</ID>
           <Description>"Language"</Description>
-          <LastState Value="1" RealAddress="012D61F4"/>
+          <LastState Value="0" RealAddress="008061F4"/>
           <VariableType>4 Bytes</VariableType>
           <Address>GGXXACPR_Win.exe+4E6164+90</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>17</ID>
           <Description>"+R on/off"</Description>
-          <LastState Value="1" RealAddress="012D620C"/>
+          <LastState Value="0" RealAddress="0080620C"/>
           <VariableType>4 Bytes</VariableType>
           <Address>GGXXACPR_Win.exe+4E6164+A8</Address>
         </CheatEntry>
@@ -68,13 +92,14 @@
     <CheatEntry>
       <ID>19</ID>
       <Description>"In-Game Values"</Description>
+      <Options moHideChildren="1"/>
       <LastState Value="" RealAddress="00000000"/>
       <GroupHeader>1</GroupHeader>
       <CheatEntries>
         <CheatEntry>
           <ID>21</ID>
           <Description>"P1 Buf1"</Description>
-          <LastState Value="00 00" RealAddress="00F61574"/>
+          <LastState Value="00 00" RealAddress="00821574"/>
           <ShowAsHex>1</ShowAsHex>
           <ShowAsSigned>0</ShowAsSigned>
           <VariableType>Array of byte</VariableType>
@@ -84,7 +109,7 @@
         <CheatEntry>
           <ID>22</ID>
           <Description>"P1 Buf2"</Description>
-          <LastState Value="00 00" RealAddress="00F61578"/>
+          <LastState Value="00 00" RealAddress="00821578"/>
           <ShowAsHex>1</ShowAsHex>
           <VariableType>Array of byte</VariableType>
           <ByteLength>2</ByteLength>
@@ -93,7 +118,7 @@
         <CheatEntry>
           <ID>23</ID>
           <Description>"P1 Buf3"</Description>
-          <LastState Value="00 00" RealAddress="00F7628C"/>
+          <LastState Value="00 00" RealAddress="0083628C"/>
           <ShowAsHex>1</ShowAsHex>
           <VariableType>Array of byte</VariableType>
           <ByteLength>2</ByteLength>
@@ -102,7 +127,7 @@
         <CheatEntry>
           <ID>38</ID>
           <Description>"P2 Buf1"</Description>
-          <LastState Value="00 00" RealAddress="00F61584"/>
+          <LastState Value="00 00" RealAddress="00821584"/>
           <ShowAsHex>1</ShowAsHex>
           <ShowAsSigned>0</ShowAsSigned>
           <VariableType>Array of byte</VariableType>
@@ -112,26 +137,33 @@
         <CheatEntry>
           <ID>39</ID>
           <Description>"P2 Buf2"</Description>
-          <LastState Value="00 00" RealAddress="00F61588"/>
+          <LastState Value="00 00" RealAddress="00821588"/>
           <ShowAsHex>1</ShowAsHex>
           <VariableType>Array of byte</VariableType>
           <ByteLength>2</ByteLength>
           <Address>GGXXACPR_Win.exe+501588</Address>
         </CheatEntry>
         <CheatEntry>
-          <ID>80</ID>
+          <ID>107</ID>
           <Description>"P1 State"</Description>
-          <LastState Value="1" RealAddress="16CAB000"/>
-          <VariableType>Byte</VariableType>
-          <Address>GGXXACPR_Win.exe+516778</Address>
-          <Offsets>
-            <Offset>0</Offset>
-          </Offsets>
+          <Options moHideChildren="1"/>
+          <LastState Value="" RealAddress="00000000"/>
+          <GroupHeader>1</GroupHeader>
           <CheatEntries>
+            <CheatEntry>
+              <ID>106</ID>
+              <Description>"P1 Player Flag"</Description>
+              <LastState Value="1" RealAddress="1680B000"/>
+              <VariableType>Byte</VariableType>
+              <Address>GGXXACPR_Win.exe+516778</Address>
+              <Offsets>
+                <Offset>0</Offset>
+              </Offsets>
+            </CheatEntry>
             <CheatEntry>
               <ID>83</ID>
               <Description>"P1 Character Facing"</Description>
-              <LastState Value="1" RealAddress="16CAB002"/>
+              <LastState Value="1" RealAddress="1680B002"/>
               <VariableType>Byte</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -141,7 +173,7 @@
             <CheatEntry>
               <ID>84</ID>
               <Description>"P1 Character Side"</Description>
-              <LastState Value="1" RealAddress="16CAB003"/>
+              <LastState Value="1" RealAddress="1680B003"/>
               <VariableType>Byte</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -151,7 +183,7 @@
             <CheatEntry>
               <ID>93</ID>
               <Description>"P1 Health"</Description>
-              <LastState Value="388" RealAddress="16CAB01E"/>
+              <LastState Value="460" RealAddress="1680B01E"/>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -161,7 +193,7 @@
             <CheatEntry>
               <ID>77</ID>
               <Description>"P1 X Position"</Description>
-              <LastState Value="43697" RealAddress="16CAB0B0"/>
+              <LastState Value="-13268" RealAddress="1680B0B0"/>
               <ShowAsSigned>1</ShowAsSigned>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
@@ -172,7 +204,7 @@
             <CheatEntry>
               <ID>82</ID>
               <Description>"P1 Y Position"</Description>
-              <LastState Value="0" RealAddress="16CAB0B4"/>
+              <LastState Value="0" RealAddress="1680B0B4"/>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -182,7 +214,7 @@
             <CheatEntry>
               <ID>85</ID>
               <Description>"P1 X Velocity"</Description>
-              <LastState Value="0" RealAddress="16CAB0B8"/>
+              <LastState Value="0" RealAddress="1680B0B8"/>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -192,7 +224,7 @@
             <CheatEntry>
               <ID>86</ID>
               <Description>"P1 Y Velocity"</Description>
-              <LastState Value="0" RealAddress="16CAB0BC"/>
+              <LastState Value="0" RealAddress="1680B0BC"/>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -202,40 +234,47 @@
             <CheatEntry>
               <ID>95</ID>
               <Description>"P1 Tension"</Description>
-              <LastState Value="10000" RealAddress="00F7A038"/>
+              <LastState Value="0" RealAddress="0083A038"/>
               <VariableType>2 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+51A038</Address>
             </CheatEntry>
             <CheatEntry>
               <ID>99</ID>
               <Description>"P1 Burst"</Description>
-              <LastState Value="15000" RealAddress="00F7A130"/>
+              <LastState Value="15000" RealAddress="0083A130"/>
               <VariableType>2 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+51A130</Address>
             </CheatEntry>
             <CheatEntry>
               <ID>105</ID>
               <Description>"P1 Guard Bar"</Description>
-              <LastState Value="0" RealAddress="00F7A052"/>
+              <LastState Value="0" RealAddress="0083A052"/>
               <VariableType>2 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+51A052</Address>
             </CheatEntry>
           </CheatEntries>
         </CheatEntry>
         <CheatEntry>
-          <ID>81</ID>
+          <ID>108</ID>
           <Description>"P2 State"</Description>
-          <LastState Value="2" RealAddress="16CAB130"/>
-          <VariableType>Byte</VariableType>
-          <Address>GGXXACPR_Win.exe+516778</Address>
-          <Offsets>
-            <Offset>0+130</Offset>
-          </Offsets>
+          <Options moHideChildren="1"/>
+          <LastState Value="" RealAddress="00000000"/>
+          <GroupHeader>1</GroupHeader>
           <CheatEntries>
+            <CheatEntry>
+              <ID>81</ID>
+              <Description>"P2 Player Flag"</Description>
+              <LastState Value="2" RealAddress="1680B130"/>
+              <VariableType>Byte</VariableType>
+              <Address>GGXXACPR_Win.exe+516778</Address>
+              <Offsets>
+                <Offset>0+130</Offset>
+              </Offsets>
+            </CheatEntry>
             <CheatEntry>
               <ID>87</ID>
               <Description>"P2 Character Facing"</Description>
-              <LastState Value="0" RealAddress="16CAB132"/>
+              <LastState Value="0" RealAddress="1680B132"/>
               <VariableType>Byte</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -245,7 +284,7 @@
             <CheatEntry>
               <ID>88</ID>
               <Description>"P2 Character Side"</Description>
-              <LastState Value="0" RealAddress="16CAB133"/>
+              <LastState Value="0" RealAddress="1680B133"/>
               <VariableType>Byte</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -255,7 +294,7 @@
             <CheatEntry>
               <ID>94</ID>
               <Description>"P2 Health"</Description>
-              <LastState Value="204" RealAddress="16CAB14E"/>
+              <LastState Value="204" RealAddress="1680B14E"/>
               <VariableType>Byte</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -265,7 +304,7 @@
             <CheatEntry>
               <ID>89</ID>
               <Description>"P2 X Position"</Description>
-              <LastState Value="49697" RealAddress="16CAB1E0"/>
+              <LastState Value="12985" RealAddress="1680B1E0"/>
               <ShowAsSigned>1</ShowAsSigned>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
@@ -276,7 +315,7 @@
             <CheatEntry>
               <ID>90</ID>
               <Description>"P2 Y Position"</Description>
-              <LastState Value="0" RealAddress="16CAB1E4"/>
+              <LastState Value="0" RealAddress="1680B1E4"/>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -286,7 +325,7 @@
             <CheatEntry>
               <ID>91</ID>
               <Description>"P2 X Velocity"</Description>
-              <LastState Value="0" RealAddress="16CAB1E8"/>
+              <LastState Value="0" RealAddress="1680B1E8"/>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -296,7 +335,7 @@
             <CheatEntry>
               <ID>92</ID>
               <Description>"P2 Y Velocity"</Description>
-              <LastState Value="0" RealAddress="16CAB1EC"/>
+              <LastState Value="0" RealAddress="1680B1EC"/>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -306,21 +345,21 @@
             <CheatEntry>
               <ID>98</ID>
               <Description>"P2 Tension"</Description>
-              <LastState Value="0" RealAddress="00F7A180"/>
+              <LastState Value="0" RealAddress="0083A180"/>
               <VariableType>2 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+51A180</Address>
             </CheatEntry>
             <CheatEntry>
               <ID>103</ID>
               <Description>"P2 Burst"</Description>
-              <LastState Value="15000" RealAddress="00F7A278"/>
+              <LastState Value="15000" RealAddress="0083A278"/>
               <VariableType>2 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+51A278</Address>
             </CheatEntry>
             <CheatEntry>
               <ID>104</ID>
               <Description>"P2 Guard Bar"</Description>
-              <LastState Value="0" RealAddress="00F7A19A"/>
+              <LastState Value="0" RealAddress="0083A19A"/>
               <ShowAsSigned>1</ShowAsSigned>
               <VariableType>2 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+51A19A</Address>
@@ -332,34 +371,35 @@
     <CheatEntry>
       <ID>20</ID>
       <Description>"Character Select Values"</Description>
+      <Options moHideChildren="1"/>
       <LastState Value="" RealAddress="00000000"/>
       <GroupHeader>1</GroupHeader>
       <CheatEntries>
         <CheatEntry>
           <ID>24</ID>
           <Description>"P1 Cursor X"</Description>
-          <LastState Value="583.666626" RealAddress="012FACE0"/>
+          <LastState Value="280" RealAddress="0082ACE0"/>
           <VariableType>Float</VariableType>
           <Address>GGXXACPR_Win.exe+50ACE0</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>25</ID>
           <Description>"P1 Cursor Y"</Description>
-          <LastState Value="315.26651" RealAddress="012FACE4"/>
+          <LastState Value="297" RealAddress="0082ACE4"/>
           <VariableType>Float</VariableType>
           <Address>GGXXACPR_Win.exe+50ACE4</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>26</ID>
           <Description>"P2 Cursor X"</Description>
-          <LastState Value="360" RealAddress="012FAD88"/>
+          <LastState Value="360" RealAddress="0082AD88"/>
           <VariableType>Float</VariableType>
           <Address>GGXXACPR_Win.exe+50AD88</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>27</ID>
           <Description>"P2 Cursor Y"</Description>
-          <LastState Value="297" RealAddress="012FAD8C"/>
+          <LastState Value="297" RealAddress="0082AD8C"/>
           <VariableType>Float</VariableType>
           <Address>GGXXACPR_Win.exe+50AD8C</Address>
         </CheatEntry>
@@ -392,7 +432,7 @@
 23:Kliff
 24:Justice
 </DropDownList>
-          <LastState Value="24" RealAddress="012FAD04"/>
+          <LastState Value="0" RealAddress="0082AD04"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+50AD04</Address>
         </CheatEntry>
@@ -425,7 +465,7 @@
 23:Kliff
 24:Justice
 </DropDownList>
-          <LastState Value="24" RealAddress="012FAD08"/>
+          <LastState Value="0" RealAddress="0082AD08"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+50AD08</Address>
         </CheatEntry>
@@ -458,15 +498,14 @@
 23:Kliff
 24:Justice
 </DropDownList>
-          <LastState Value="24" RealAddress="012FAD0C"/>
+          <LastState Value="0" RealAddress="0082AD0C"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+50AD0C</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>32</ID>
           <Description>"P1 Palette"</Description>
-          <DropDownList DisplayValueAsItem="1">
-          0:AC P
+          <DropDownList DisplayValueAsItem="1">0:AC P
           1:AC K
           2:AC S
           3:AC H
@@ -486,21 +525,22 @@
           17:Reload S
           18:Reload H
           19:Reload D
-          </DropDownList>
-          <LastState Value="2" RealAddress="012FAD24"/>
+          
+</DropDownList>
+          <LastState Value="16" RealAddress="0082AD24"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+50AD24</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>37</ID>
           <Description>"P1 Palette Group"</Description>
-          <LastState Value="0" RealAddress="01345C7C"/>
-          <DropDownList DisplayValueAsItem="1">
-          0:AC
+          <DropDownList DisplayValueAsItem="1">0:AC
           1:EX
           2:Slash
           3:Reload
-          </DropDownList>
+          
+</DropDownList>
+          <LastState Value="0" RealAddress="00875C7C"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+555C7C</Address>
         </CheatEntry>
@@ -533,7 +573,7 @@
 23:Kliff
 24:Justice
 </DropDownList>
-          <LastState Value="1" RealAddress="012FADB0"/>
+          <LastState Value="1" RealAddress="0082ADB0"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+50ADB0</Address>
         </CheatEntry>
@@ -566,7 +606,7 @@
 23:Kliff
 24:Justice
 </DropDownList>
-          <LastState Value="1" RealAddress="012FADB4"/>
+          <LastState Value="1" RealAddress="0082ADB4"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+50ADB4</Address>
         </CheatEntry>
@@ -599,15 +639,14 @@
 23:Kliff
 24:Justice
 </DropDownList>
-          <LastState Value="0" RealAddress="012FADB8"/>
+          <LastState Value="0" RealAddress="0082ADB8"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+50ADB8</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>36</ID>
           <Description>"P2 Palette"</Description>
-          <DropDownList DisplayValueAsItem="1">
-          0:AC P
+          <DropDownList DisplayValueAsItem="1">0:AC P
           1:AC K
           2:AC S
           3:AC H
@@ -627,8 +666,9 @@
           17:Reload S
           18:Reload H
           19:Reload D
-          </DropDownList>
-          <LastState Value="10" RealAddress="012FADD0"/>
+          
+</DropDownList>
+          <LastState Value="10" RealAddress="0082ADD0"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+50ADD0</Address>
         </CheatEntry>
@@ -655,7 +695,7 @@
 17:Grave
 18:Heaven
 </DropDownList>
-          <LastState Value="15" RealAddress="01345C44"/>
+          <LastState Value="7" RealAddress="00875C44"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+555C44</Address>
         </CheatEntry>
@@ -700,34 +740,11 @@
 35:33 Pride and Glory -Kliff-
 36:34 Meet Again -Justice-
 </DropDownList>
-          <LastState Value="0" RealAddress="011DACDC"/>
+          <LastState Value="1" RealAddress="0070ACDC"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+3EACDC</Address>
         </CheatEntry>
       </CheatEntries>
-    </CheatEntry>
-     <CheatEntry>
-      <ID>43</ID>
-      <Description>"Disable IsDebuggerPresent"</Description>
-      <LastState/>
-      <VariableType>Auto Assembler Script</VariableType>
-      <AssemblerScript>define(address,"KERNELBASE.IsDebuggerPresent")
-define(bytes, 64 A1 30 00 00 00 0F B6 40 02)
-[ENABLE]
-assert(address, bytes)
-
-address:
-        mov eax, 0
-        nop
-        nop
-        nop
-        nop
-        nop
-
-[DISABLE]
-address:
-         db bytes
-</AssemblerScript>
     </CheatEntry>
   </CheatEntries>
   <UserdefinedSymbols/>


### PR DESCRIPTION
- Moved `Disable IsDebuggerPresent` to the top (might put this in a scripts header if we end up with more of them)
- Made `Settings` collapsible
- Made `In-Game Values` collapsible
- Moved `P1 State` address to `P1 Player Flag` address
- Added collapsible `P1 State` header
- Same thing as ^ but for P2
- Made `Character Select Values` header collapsible