### PR TITLE
WIP: Character specific resources

### DIFF
--- a/GGXXACPR_Win.CT
+++ b/GGXXACPR_Win.CT
@@ -234,7 +234,7 @@ address:
               <ID>147</ID>
               <Description>"P1 Dizzy"</Description>
               <VariableType>2 Bytes</VariableType>
-              <Address>0150A0B6</Address>
+              <Address>GGXXACPR_Win.exe+51A0B4+2</Address>
             </CheatEntry>
             <CheatEntry>
               <ID>111</ID>
@@ -468,7 +468,7 @@ address:
               <ID>146</ID>
               <Description>"P2 Dizzy"</Description>
               <VariableType>2 Bytes</VariableType>
-              <Address>0150A1FE</Address>
+              <Address>GGXXACPR_Win.exe+51A1FC+2</Address>
             </CheatEntry>
             <CheatEntry>
               <ID>114</ID>

--- a/GGXXACPR_Win.CT
+++ b/GGXXACPR_Win.CT
@@ -224,6 +224,140 @@ address:
               <VariableType>2 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+51A052</Address>
             </CheatEntry>
+            <CheatEntry>
+              <ID>144</ID>
+              <Description>"P1 Stun"</Description>
+              <VariableType>2 Bytes</VariableType>
+              <Address>GGXXACPR_Win.exe+51A0B4</Address>
+            </CheatEntry>
+            <CheatEntry>
+              <ID>147</ID>
+              <Description>"P1 Dizzy"</Description>
+              <VariableType>2 Bytes</VariableType>
+              <Address>0150A0B6</Address>
+            </CheatEntry>
+            <CheatEntry>
+              <ID>111</ID>
+              <Description>"Character Specific"</Description>
+              <Options moHideChildren="1" />
+              <GroupHeader>1</GroupHeader>
+              <CheatEntries>
+                <CheatEntry>
+                  <ID>109</ID>
+                  <Description>"Order Sol Gauge"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A0CE</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>110</ID>
+                  <Description>"Order Sol Remaining Gauge"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A0C8</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>115</ID>
+                  <Description>"Eddie Gauge"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A0C4</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>117</ID>
+                  <Description>"Testament Dolls"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A0C4</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>133</ID>
+                  <Description>"Testament Curse"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A0C8</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>119</ID>
+                  <Description>"Robo-Ky Heat Gauge"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A0C4</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>122</ID>
+                  <Description>"Johnny Coins (Invert)"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A0C4</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>123</ID>
+                  <Description>"Johnny Mist Finer Level"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A0C0</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>125</ID>
+                  <Description>"ABA Moroha Mode"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A0C0</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>127</ID>
+                  <Description>"ABA Blood Packs"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>0109A0C2</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>126</ID>
+                  <Description>"ABA Moroha Gauge"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A0C8</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>131</ID>
+                  <Description>"Chipp Shuriken"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A0C6</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>135</ID>
+                  <Description>"Zappa Countdown?"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A0C6</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>136</ID>
+                  <Description>"Zappa RNG?"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>0109A0C2</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>137</ID>
+                  <Description>"Zappa Active Summon"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A0C0</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>138</ID>
+                  <Description>"Jam 22K Card"</Description>
+                  <VariableType>Byte</VariableType>
+                  <Address>0109A0C2</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>140</ID>
+                  <Description>"Jam 22H Card"</Description>
+                  <VariableType>Byte</VariableType>
+                  <Address>0109A0C4</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>139</ID>
+                  <Description>"Jam 22S Card"</Description>
+                  <VariableType>Byte</VariableType>
+                  <Address>0109A0C5</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>148</ID>
+                  <Description>"Justice Omega Shift"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A0C0</Address>
+                </CheatEntry>
+              </CheatEntries>
+            </CheatEntry>
           </CheatEntries>
         </CheatEntry>
         <CheatEntry>
@@ -323,6 +457,122 @@ address:
               <ShowAsSigned>1</ShowAsSigned>
               <VariableType>2 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+51A19A</Address>
+            </CheatEntry>
+            <CheatEntry>
+              <ID>145</ID>
+              <Description>"P2 Stun"</Description>
+              <VariableType>2 Bytes</VariableType>
+              <Address>GGXXACPR_Win.exe+51A1FC</Address>
+            </CheatEntry>
+            <CheatEntry>
+              <ID>146</ID>
+              <Description>"P2 Dizzy"</Description>
+              <VariableType>2 Bytes</VariableType>
+              <Address>0150A1FE</Address>
+            </CheatEntry>
+            <CheatEntry>
+              <ID>114</ID>
+              <Description>"Character Specific"</Description>
+              <Options moHideChildren="1" />
+              <GroupHeader>1</GroupHeader>
+              <CheatEntries>
+                <CheatEntry>
+                  <ID>113</ID>
+                  <Description>"Order Sol Gauge"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A216</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>112</ID>
+                  <Description>"Order Sol Remaining Gauge"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A210</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>116</ID>
+                  <Description>"Eddie Gauge"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A20C</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>118</ID>
+                  <Description>"Testament Dolls"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A20C</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>134</ID>
+                  <Description>"Testament Curse"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A210</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>120</ID>
+                  <Description>"Robo-Ky Heat Gauge"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A20C</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>121</ID>
+                  <Description>"Johnny Coins (Invert)"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A20C</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>124</ID>
+                  <Description>"Johnny Mist Finer Level"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A208</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>130</ID>
+                  <Description>"ABA Moroha Mode"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A208</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>129</ID>
+                  <Description>"ABA Blood Packs"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A20A</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>128</ID>
+                  <Description>"ABA Moroha Gauge"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A210</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>132</ID>
+                  <Description>"Chipp Shuriken"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A20E</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>141</ID>
+                  <Description>"Jam 22K Card"</Description>
+                  <VariableType>Byte</VariableType>
+                  <Address>0109A20A</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>143</ID>
+                  <Description>"Jam 22H Card"</Description>
+                  <VariableType>Byte</VariableType>
+                  <Address>0109A20C</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>142</ID>
+                  <Description>"Jam 22S Card"</Description>
+                  <VariableType>Byte</VariableType>
+                  <Address>0109A20D</Address>
+                </CheatEntry>
+                <CheatEntry>
+                  <ID>149</ID>
+                  <Description>"Justice Omega Shift"</Description>
+                  <VariableType>2 Bytes</VariableType>
+                  <Address>GGXXACPR_Win.exe+51A208</Address>
+                </CheatEntry>
+              </CheatEntries>
             </CheatEntry>
           </CheatEntries>
         </CheatEntry>

--- a/GGXXACPR_Win.CT
+++ b/GGXXACPR_Win.CT
@@ -1,65 +1,56 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <CheatTable CheatEngineTableVersion="29">
   <CheatEntries>
     <CheatEntry>
       <ID>18</ID>
       <Description>"Settings"</Description>
-      <LastState Value="" RealAddress="00000000"/>
       <GroupHeader>1</GroupHeader>
       <CheatEntries>
         <CheatEntry>
           <ID>3</ID>
           <Description>"Difficulty"</Description>
-          <LastState Value="2" RealAddress="012D6164"/>
           <VariableType>4 Bytes</VariableType>
           <Address>GGXXACPR_Win.exe+4E6164+0</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>5</ID>
           <Description>"Time"</Description>
-          <LastState Value="2" RealAddress="012D617C"/>
           <VariableType>4 Bytes</VariableType>
           <Address>GGXXACPR_Win.exe+4E6164+18</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>7</ID>
           <Description>"Rounds"</Description>
-          <LastState Value="1" RealAddress="012D6194"/>
           <VariableType>4 Bytes</VariableType>
           <Address>GGXXACPR_Win.exe+4E6164+30</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>9</ID>
           <Description>"Victory BGM"</Description>
-          <LastState Value="0" RealAddress="012D61AC"/>
           <VariableType>4 Bytes</VariableType>
           <Address>GGXXACPR_Win.exe+4E6164+48</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>11</ID>
           <Description>"Sol VA"</Description>
-          <LastState Value="0" RealAddress="012D61C4"/>
           <VariableType>4 Bytes</VariableType>
           <Address>GGXXACPR_Win.exe+4E6164+60</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>13</ID>
           <Description>"HOS VA"</Description>
-          <LastState Value="0" RealAddress="012D61DC"/>
           <VariableType>4 Bytes</VariableType>
           <Address>GGXXACPR_Win.exe+4E6164+78</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>15</ID>
           <Description>"Language"</Description>
-          <LastState Value="1" RealAddress="012D61F4"/>
           <VariableType>4 Bytes</VariableType>
           <Address>GGXXACPR_Win.exe+4E6164+90</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>17</ID>
           <Description>"+R on/off"</Description>
-          <LastState Value="1" RealAddress="012D620C"/>
           <VariableType>4 Bytes</VariableType>
           <Address>GGXXACPR_Win.exe+4E6164+A8</Address>
         </CheatEntry>
@@ -68,13 +59,11 @@
     <CheatEntry>
       <ID>19</ID>
       <Description>"In-Game Values"</Description>
-      <LastState Value="" RealAddress="00000000"/>
       <GroupHeader>1</GroupHeader>
       <CheatEntries>
         <CheatEntry>
           <ID>21</ID>
           <Description>"P1 Buf1"</Description>
-          <LastState Value="00 00" RealAddress="00F61574"/>
           <ShowAsHex>1</ShowAsHex>
           <ShowAsSigned>0</ShowAsSigned>
           <VariableType>Array of byte</VariableType>
@@ -84,7 +73,6 @@
         <CheatEntry>
           <ID>22</ID>
           <Description>"P1 Buf2"</Description>
-          <LastState Value="00 00" RealAddress="00F61578"/>
           <ShowAsHex>1</ShowAsHex>
           <VariableType>Array of byte</VariableType>
           <ByteLength>2</ByteLength>
@@ -93,7 +81,6 @@
         <CheatEntry>
           <ID>23</ID>
           <Description>"P1 Buf3"</Description>
-          <LastState Value="00 00" RealAddress="00F7628C"/>
           <ShowAsHex>1</ShowAsHex>
           <VariableType>Array of byte</VariableType>
           <ByteLength>2</ByteLength>
@@ -102,7 +89,6 @@
         <CheatEntry>
           <ID>38</ID>
           <Description>"P2 Buf1"</Description>
-          <LastState Value="00 00" RealAddress="00F61584"/>
           <ShowAsHex>1</ShowAsHex>
           <ShowAsSigned>0</ShowAsSigned>
           <VariableType>Array of byte</VariableType>
@@ -112,7 +98,6 @@
         <CheatEntry>
           <ID>39</ID>
           <Description>"P2 Buf2"</Description>
-          <LastState Value="00 00" RealAddress="00F61588"/>
           <ShowAsHex>1</ShowAsHex>
           <VariableType>Array of byte</VariableType>
           <ByteLength>2</ByteLength>
@@ -121,7 +106,6 @@
         <CheatEntry>
           <ID>80</ID>
           <Description>"P1 State"</Description>
-          <LastState Value="1" RealAddress="16CAB000"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+516778</Address>
           <Offsets>
@@ -131,7 +115,6 @@
             <CheatEntry>
               <ID>83</ID>
               <Description>"P1 Character Facing"</Description>
-              <LastState Value="1" RealAddress="16CAB002"/>
               <VariableType>Byte</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -141,7 +124,6 @@
             <CheatEntry>
               <ID>84</ID>
               <Description>"P1 Character Side"</Description>
-              <LastState Value="1" RealAddress="16CAB003"/>
               <VariableType>Byte</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -151,7 +133,6 @@
             <CheatEntry>
               <ID>93</ID>
               <Description>"P1 Health"</Description>
-              <LastState Value="388" RealAddress="16CAB01E"/>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -161,7 +142,6 @@
             <CheatEntry>
               <ID>77</ID>
               <Description>"P1 X Position"</Description>
-              <LastState Value="43697" RealAddress="16CAB0B0"/>
               <ShowAsSigned>1</ShowAsSigned>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
@@ -172,7 +152,6 @@
             <CheatEntry>
               <ID>82</ID>
               <Description>"P1 Y Position"</Description>
-              <LastState Value="0" RealAddress="16CAB0B4"/>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -182,7 +161,6 @@
             <CheatEntry>
               <ID>85</ID>
               <Description>"P1 X Velocity"</Description>
-              <LastState Value="0" RealAddress="16CAB0B8"/>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -192,7 +170,6 @@
             <CheatEntry>
               <ID>86</ID>
               <Description>"P1 Y Velocity"</Description>
-              <LastState Value="0" RealAddress="16CAB0BC"/>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -202,21 +179,18 @@
             <CheatEntry>
               <ID>95</ID>
               <Description>"P1 Tension"</Description>
-              <LastState Value="10000" RealAddress="00F7A038"/>
               <VariableType>2 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+51A038</Address>
             </CheatEntry>
             <CheatEntry>
               <ID>99</ID>
               <Description>"P1 Burst"</Description>
-              <LastState Value="15000" RealAddress="00F7A130"/>
               <VariableType>2 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+51A130</Address>
             </CheatEntry>
             <CheatEntry>
               <ID>105</ID>
               <Description>"P1 Guard Bar"</Description>
-              <LastState Value="0" RealAddress="00F7A052"/>
               <VariableType>2 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+51A052</Address>
             </CheatEntry>
@@ -225,7 +199,6 @@
         <CheatEntry>
           <ID>81</ID>
           <Description>"P2 State"</Description>
-          <LastState Value="2" RealAddress="16CAB130"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+516778</Address>
           <Offsets>
@@ -235,7 +208,6 @@
             <CheatEntry>
               <ID>87</ID>
               <Description>"P2 Character Facing"</Description>
-              <LastState Value="0" RealAddress="16CAB132"/>
               <VariableType>Byte</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -245,7 +217,6 @@
             <CheatEntry>
               <ID>88</ID>
               <Description>"P2 Character Side"</Description>
-              <LastState Value="0" RealAddress="16CAB133"/>
               <VariableType>Byte</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -255,7 +226,6 @@
             <CheatEntry>
               <ID>94</ID>
               <Description>"P2 Health"</Description>
-              <LastState Value="204" RealAddress="16CAB14E"/>
               <VariableType>Byte</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -265,7 +235,6 @@
             <CheatEntry>
               <ID>89</ID>
               <Description>"P2 X Position"</Description>
-              <LastState Value="49697" RealAddress="16CAB1E0"/>
               <ShowAsSigned>1</ShowAsSigned>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
@@ -276,7 +245,6 @@
             <CheatEntry>
               <ID>90</ID>
               <Description>"P2 Y Position"</Description>
-              <LastState Value="0" RealAddress="16CAB1E4"/>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -286,7 +254,6 @@
             <CheatEntry>
               <ID>91</ID>
               <Description>"P2 X Velocity"</Description>
-              <LastState Value="0" RealAddress="16CAB1E8"/>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -296,7 +263,6 @@
             <CheatEntry>
               <ID>92</ID>
               <Description>"P2 Y Velocity"</Description>
-              <LastState Value="0" RealAddress="16CAB1EC"/>
               <VariableType>4 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+516778</Address>
               <Offsets>
@@ -306,21 +272,18 @@
             <CheatEntry>
               <ID>98</ID>
               <Description>"P2 Tension"</Description>
-              <LastState Value="0" RealAddress="00F7A180"/>
               <VariableType>2 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+51A180</Address>
             </CheatEntry>
             <CheatEntry>
               <ID>103</ID>
               <Description>"P2 Burst"</Description>
-              <LastState Value="15000" RealAddress="00F7A278"/>
               <VariableType>2 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+51A278</Address>
             </CheatEntry>
             <CheatEntry>
               <ID>104</ID>
               <Description>"P2 Guard Bar"</Description>
-              <LastState Value="0" RealAddress="00F7A19A"/>
               <ShowAsSigned>1</ShowAsSigned>
               <VariableType>2 Bytes</VariableType>
               <Address>GGXXACPR_Win.exe+51A19A</Address>
@@ -332,34 +295,29 @@
     <CheatEntry>
       <ID>20</ID>
       <Description>"Character Select Values"</Description>
-      <LastState Value="" RealAddress="00000000"/>
       <GroupHeader>1</GroupHeader>
       <CheatEntries>
         <CheatEntry>
           <ID>24</ID>
           <Description>"P1 Cursor X"</Description>
-          <LastState Value="583.666626" RealAddress="012FACE0"/>
           <VariableType>Float</VariableType>
           <Address>GGXXACPR_Win.exe+50ACE0</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>25</ID>
           <Description>"P1 Cursor Y"</Description>
-          <LastState Value="315.26651" RealAddress="012FACE4"/>
           <VariableType>Float</VariableType>
           <Address>GGXXACPR_Win.exe+50ACE4</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>26</ID>
           <Description>"P2 Cursor X"</Description>
-          <LastState Value="360" RealAddress="012FAD88"/>
           <VariableType>Float</VariableType>
           <Address>GGXXACPR_Win.exe+50AD88</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>27</ID>
           <Description>"P2 Cursor Y"</Description>
-          <LastState Value="297" RealAddress="012FAD8C"/>
           <VariableType>Float</VariableType>
           <Address>GGXXACPR_Win.exe+50AD8C</Address>
         </CheatEntry>
@@ -392,7 +350,6 @@
 23:Kliff
 24:Justice
 </DropDownList>
-          <LastState Value="24" RealAddress="012FAD04"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+50AD04</Address>
         </CheatEntry>
@@ -425,7 +382,6 @@
 23:Kliff
 24:Justice
 </DropDownList>
-          <LastState Value="24" RealAddress="012FAD08"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+50AD08</Address>
         </CheatEntry>
@@ -458,7 +414,6 @@
 23:Kliff
 24:Justice
 </DropDownList>
-          <LastState Value="24" RealAddress="012FAD0C"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+50AD0C</Address>
         </CheatEntry>
@@ -487,14 +442,12 @@
           18:Reload H
           19:Reload D
           </DropDownList>
-          <LastState Value="2" RealAddress="012FAD24"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+50AD24</Address>
         </CheatEntry>
         <CheatEntry>
           <ID>37</ID>
           <Description>"P1 Palette Group"</Description>
-          <LastState Value="0" RealAddress="01345C7C"/>
           <DropDownList DisplayValueAsItem="1">
           0:AC
           1:EX
@@ -533,7 +486,6 @@
 23:Kliff
 24:Justice
 </DropDownList>
-          <LastState Value="1" RealAddress="012FADB0"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+50ADB0</Address>
         </CheatEntry>
@@ -566,7 +518,6 @@
 23:Kliff
 24:Justice
 </DropDownList>
-          <LastState Value="1" RealAddress="012FADB4"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+50ADB4</Address>
         </CheatEntry>
@@ -599,7 +550,6 @@
 23:Kliff
 24:Justice
 </DropDownList>
-          <LastState Value="0" RealAddress="012FADB8"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+50ADB8</Address>
         </CheatEntry>
@@ -628,7 +578,6 @@
           18:Reload H
           19:Reload D
           </DropDownList>
-          <LastState Value="10" RealAddress="012FADD0"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+50ADD0</Address>
         </CheatEntry>
@@ -655,7 +604,6 @@
 17:Grave
 18:Heaven
 </DropDownList>
-          <LastState Value="15" RealAddress="01345C44"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+555C44</Address>
         </CheatEntry>
@@ -700,7 +648,6 @@
 35:33 Pride and Glory -Kliff-
 36:34 Meet Again -Justice-
 </DropDownList>
-          <LastState Value="0" RealAddress="011DACDC"/>
           <VariableType>Byte</VariableType>
           <Address>GGXXACPR_Win.exe+3EACDC</Address>
         </CheatEntry>
@@ -709,7 +656,6 @@
      <CheatEntry>
       <ID>43</ID>
       <Description>"Disable IsDebuggerPresent"</Description>
-      <LastState/>
       <VariableType>Auto Assembler Script</VariableType>
       <AssemblerScript>define(address,"KERNELBASE.IsDebuggerPresent")
 define(bytes, 64 A1 30 00 00 00 0F B6 40 02)
@@ -730,5 +676,5 @@ address:
 </AssemblerScript>
     </CheatEntry>
   </CheatEntries>
-  <UserdefinedSymbols/>
+  <UserdefinedSymbols />
 </CheatTable>

--- a/clean_table.py
+++ b/clean_table.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 from xml.etree import ElementTree
+from pathlib import Path
 
 
 def main():
-    tree = ElementTree.parse('GGXXACPR_Win.CT')
+    path = Path(__file__).parent / 'GGXXACPR_Win.CT'
+    tree = ElementTree.parse(path)
     root = tree.getroot()
 
     for cheat_entry in root.findall('.//CheatEntry'):
@@ -11,7 +13,7 @@ def main():
         if last_state is not None:
             cheat_entry.remove(last_state)
 
-    tree.write('GGXXACPR_Win.CT', xml_declaration=True, encoding='utf-8')
+    tree.write(path, xml_declaration=True, encoding='utf-8')
 
 
 if __name__ == '__main__':

--- a/clean_table.py
+++ b/clean_table.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+from xml.etree import ElementTree
+
+
+def main():
+    tree = ElementTree.parse('GGXXACPR_Win.CT')
+    root = tree.getroot()
+
+    for cheat_entry in root.findall('.//CheatEntry'):
+        last_state = cheat_entry.find('LastState')
+        if last_state is not None:
+            cheat_entry.remove(last_state)
+
+    tree.write('GGXXACPR_Win.CT', xml_declaration=True, encoding='utf-8')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This should be most of them. Still needs to be de-duplicated and documented.

🥓 's and Faust's status effects (disabling buttons/abilities/poison) aren't in this little block of memory.

Someone has to figure out what the deal is with Zappa's values. It appears to have a value that constantly shifts which suggests it's an RNG value, but `NOP`ing out the instruction that writes to it doesn't seem to affect the summons. There's also another bit of memory that seems to be related to the timer/countdown. It seems to match up with the pattern people found and documented in the wikis.

![](https://cdn.discordapp.com/attachments/631569398242738177/634956970998366209/unknown.png)

List of character state stuff, thanks to ClassicalFightingGamer:

> Ky: None
Sol: None
Millia: None
Venom: None
Chipp: Fast/Slow Shuriken
May: None
Potemkin: None
Axl: None
Eddie: A meter for little Eddie, visually starts yellow, when empty turns red until it refills, can be increased above maximum to blue for Force Break Exhaustion.
Testament: Gains stocks, doll figures. These buff his nets and trees. Dolls are gained by his key super or airthrowing.
Baiken: None, however she can seal an opponent's button which appears above their meter.
Venom: None
Anji: None
Jam: Gains stocks in the form of cards, 3 different types of cards, of which she can gain up to 3 each. Cards give her D versions of her kick special moves.
Johnny: Has 8 coins. Hitting the opponent with a coin increases his Mist Finer level by 1, up to level 3. These levels visibly appear above his meter when his level changes or when he holds mist finer. Levels can also be increased from his jackhound follow-up force break.
Faust: His coin thrown item when hit gives him "Dissu" which powers up his next hand slap either from the fishingpole combo finisher or from his forcebreak.
I-No: None.
Slayer: None.
Bridget: None.
Zappa: Has 4 symbols above his meter depicting which summon he has.
ABA: has a normal meter whenever she enter moroha mode. If she gets knocked down it gets reduced by 25%. When empty she forcefully goes back to normal mode. She has Goku Moroha Mode which is a super move install. It works the same except that it's blue in color.
ABA also has 3 stocks in the form of blood packs. She can use a bloodpack to enter moroha mode or leave moroha mode. She also consumes a blood pack when using the Goku Moroha install.
Kliff: None.
Justice: I forgot if Omega Shift install has a meter for a timer or not. Nobody ever uses Omega Shift.
